### PR TITLE
Feature: simplified and advanced views

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -17,11 +17,29 @@ body {
 
 header {
   height: 4rem;
+  line-height: 4rem;
   display: block;
   width: 100%;
   background: #333;
   box-shadow: 0 4px 4px -4px rgba(0,0,0,0.4);
 }
+
+body:not(#code) header span {
+  color: white;
+}
+
+body:not(#code) header span:nth-child(1) {
+  font-family: "Lobster", cursive;
+  font-size: 2em;
+  margin-left: 2rem;
+}
+
+body:not(#code) header span:nth-child(2) {
+  font-family: "Comfortaa", cursive;
+  text-transform: uppercase;
+  font-size: 1.6em;
+}
+
 
 #code header {
   background: transparent;
@@ -93,10 +111,10 @@ section {
   height: 100%;
   top: 0;
   left: 0;
-  padding-top: 4rem;
   transform: translateX(100%);
   transition: transform ease-in-out;
   transition-duration: 0.5s;
+  padding-top: 4rem;
 }
 
 main section:first-of-type {
@@ -157,8 +175,9 @@ input:checked + section {
 
 #videoView {
   display: flex;
-  justify-content: space-evenly;
+  justify-content: space-between;
   align-items: flex-end;
+  padding: 0 2rem;
 }
 
 .mediadevice {
@@ -166,6 +185,17 @@ input:checked + section {
   width: 30%;
   position: relative;
   box-shadow: 0 2px 4px rgba(0,0,0,0.15);
+}
+
+.mediadevice:not(.audioDevice) {
+  transition: width 0.5s;
+}
+
+.mediadevice.audioDevice {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 30% !important;
 }
 
 .mediadevice::before {
@@ -417,6 +447,35 @@ input:checked + section {
   box-shadow: 0 -1px 1px rgba(0,0,0,0.2);
   padding: 0;
   margin: 0;
+  opacity: 0;
+  visibility: hidden;
+  transition: visibility 0s 0.5s, opacity 0.5s;
+}
+
+#advancedUserView:checked ~ #streams {
+  opacity: 1;
+  visibility: visible;
+  transition: visibility 0s, opacity 0.5s;
+}
+
+#simpleUserView:checked ~ #videoView .mediadevice {
+  width: 45%;
+  transition: width 0.5s 0.5s;
+}
+
+#simpleUserView:checked ~ #videoView .mediadevice.audioDevice,
+#simpleUserView:checked ~ label[for=mergestreams].mediadevice {
+  opacity: 0;
+  visibility: hidden;
+  position: absolute;
+  transition: opacity 0.5s, visibility 0s 0.5s;
+}
+
+#advancedUserView:checked ~ #videoView .mediadevice.audioDevice,
+#advancedUserView:checked ~ label[for=mergestreams].mediadevice {
+  opacity: 1;
+  visibility: visible;
+  transition: opacity 0.3s 0.5s, visibility 0s 0.5s, position 0s;
 }
 
 #streams::before {
@@ -600,6 +659,7 @@ svg {
 }
 
 #toggleAddDeviceModal:checked ~ #addDeviceModal,
+#toggleSaveCreationModal:checked ~ #saveCreation,
 #toggleExtensionModal:checked ~ #extensionModal {
   transform: translateY(0);
   transition: transform 0.25s ease-out;
@@ -613,11 +673,40 @@ svg {
   line-height: 5rem;
 }
 
+.modalBody h4 {
+  padding: 0;
+}
+
 .modalClose {
 }
 
 .modalBody {
   padding: 1rem;
+}
+
+.modalFooter {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 4rem;
+  padding: 1rem;
+  text-align: right;
+  width: 100%;
+}
+
+.modalFooter .btn {
+  border: none;
+  margin-left: 0.5rem;
+  border-radius: 0.125rem;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.2);
+  font-family: Ubuntu, Roboto, "Open Sans", "Segoe UI", "Helvetica Neue", Verdana, sans-serif;
+  height: 2rem;
+  line-height: 2rem;
+  padding: 0 0.5rem;
+  display: inline-block;
+  vertical-align: top;
+  font-size: 1.125rem;
+  font-weight: 300;
 }
 
 #qrcode {
@@ -778,5 +867,219 @@ label[for=mergestreams] {
 
 label[for=audiostream]::before,
 label[for=mergestreams]::before {
-  margin-top: calc(37.5% - 0.5rem);
+  margin-top: calc(37.5% - 1rem);
+}
+
+.viewControls {
+  height: 4rem;
+  line-height: 4rem;
+  text-align: right;
+  position: absolute;
+  top: 0;
+  right: 2rem;
+  font-size: 1.25rem;
+}
+
+.viewControls select {
+  font-size: 1.25rem;
+  background: white;
+  border: 1px solid #eee;
+  height: 2rem;
+  padding: 0 0.5rem;
+  border-radius: 0.25rem;
+  font-weight: 300;
+  font-family: Ubuntu, Roboto, "Open Sans", "Segoe UI", "Helvetica Neue", Verdana, sans-serif;
+}
+
+.viewControls select::before {
+  content: 'View:';
+}
+
+#recordingControls {
+  text-align: center;
+  margin: 2rem 0;
+  position: relative;
+}
+
+#recordingControls button {
+  width: 4rem;
+  height: 4rem;
+  border-radius: 0.25rem;
+  border: none;
+  position: relative;
+  margin: 0 0.5rem;
+  background: linear-gradient(to bottom, #f4f4f4 0%, #f0f0f0 100%);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.2);
+  outline: none;
+}
+
+#startRecord::before {
+  position: absolute;
+  width: 2rem;
+  height: 2rem;
+  background: #8d2351;
+  border-radius: 50%;
+  top: 1rem;
+  left: 1rem;
+  content: '';
+}
+
+.recording #startRecord::before {
+  background: #fe0001;
+}
+
+.recording #startRecord {
+  box-shadow: inset 0 2px 3px rgba(0,0,0,0.2);
+}
+
+.paused #pauseRecord {
+  box-shadow: inset 0 2px 3px rgba(0,0,0,0.2);
+}
+
+#pauseRecord::before {
+  position: absolute;
+  width: 0.5rem;
+  height: 1.5rem;
+  border: 0.5rem solid #888;
+  border-top: none;
+  border-bottom: none;
+  top: 1.25rem;
+  left: 1.25rem;
+  content: '';
+}
+
+.recording #pauseRecord::before {
+  border-color: black;
+}
+
+#stopRecord::before {
+  position: absolute;
+  width: 1.5rem;
+  height: 1.5rem;
+  top: 1.25rem;
+  left: 1.25rem;
+  content: '';
+  background: #888;
+}
+
+.recording #stopRecord::before {
+  background: black;
+}
+
+label, button {
+  cursor: pointer;
+}
+
+#recordingTime {
+  line-height: 4rem; 
+  position: absolute;
+  top: 0;
+  right: 2rem;
+}
+
+#recordingTime::before {
+  font-weight: 300;
+  margin-right: 0.5rem;
+}
+
+.recording #recordingTime::before {
+  content: 'Recording';
+  font-style: italic;
+  color: #fe0001;
+}
+
+.paused.recording #recordingTime::before {
+  content: 'Paused';
+  font-style: normal;
+  color: teal;
+}
+
+
+.thirdWidth {
+  width: calc(100%/3);
+  display: inline-block;
+}
+
+.twoThirdWidth {
+  width: calc(200%/3);
+  display: inline-block;
+}
+
+.quarterWidth {
+  width: 25%;
+  display: inline-block;
+}
+
+.threeQuarterWidth {
+  width: 75%;
+  display: inline-block;
+}
+.pull-left {
+  float: left;
+}
+
+.pull-right {
+  float: right;
+}
+
+.clear {
+  clear: both;
+}
+
+ul {
+  margin: 0;
+  padding: 0;
+  line-height: 2.5rem;
+}
+
+input {
+  border: 1px solid #ccc;
+  height: 2rem;
+  border-radius: 0.125rem;
+  padding: 0 0.5rem;
+  outline: none;
+  transition: border-color 0.3s, box-shadow 0.3s;
+  font-family: Ubuntu, Roboto, "Open Sans", "Segoe UI", "Helvetica Neue", Verdana, sans-serif;
+}
+
+input:focus {
+  border-color: #09f;
+  box-shadow: 0 0 3px #8cf;
+}
+
+#recordingList {
+  display: flex;
+  max-height: 6.5rem;
+  overflow-y: auto;
+}
+
+#recordingList a {
+  width: 8rem;
+  height: 6rem;
+  position: relative;
+  background: #f4f4f4;
+  text-align: center;
+  padding: 0.5rem;
+  margin: 0 0.5rem 0.5rem 0;
+}
+
+#recordingList a video {
+  position: absolute;
+  max-width: 100%;
+  max-height: 100%;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.btn-success {
+  background: #1DE9B6;
+}
+
+.btn-action {
+  background: #64B5F6;
+}
+
+.btn-cancel {
+  background: #F4FF81;
 }

--- a/index.html
+++ b/index.html
@@ -4,16 +4,18 @@
   <meta charset="utf8">
   <meta name="viewport" content="width=device-width">
   <meta name="google-site-verification" content="zLyTJjR3SdsG8d0wR5jdHzmm5170gpm_KFfGcy4RfDs" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https: ws: wss:; style-src 'self'; media-src 'self' blob:; img-src 'self' data:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https: ws: wss:; style-src 'self' https://fonts.googleapis.com ; media-src 'self' blob:; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com">
   <title>GhettoStudio</title>
   <link rel="stylesheet" href="css/style.css">
   <link rel="chrome-webstore-item" href="https://chrome.google.com/webstore/detail/oghkihildgnkedhlolgjomnbfmjpmddm">
 </head>
 <body>
   <header>
+    <span>Ghetto</span><span>Studio</span>
   </header>
   <input type="checkbox" class="toggleCover addDevice hiddenCheck" id="toggleExtensionModal" />
   <input type="checkbox" class="toggleCover hiddenCheck" id="toggleAddDeviceModal" />
+  <input type="checkbox" class="toggleCover hiddenCheck" id="toggleSaveCreationModal" />
   <div id="cover"></div>
   <main>
     <div class="content">
@@ -23,9 +25,17 @@
     </section>
     <input type="radio" id="create" class="hiddenCheck" name="view" />
     <section>
+      <input name="userView" type="radio" value="simple" class="hiddenCheck" checked id="simpleUserView"/>
+      <input name="userView" type="radio" value="advanced" class="hiddenCheck" id="advancedUserView" />
       <input type="checkbox" name="merge" class="hiddenCheck" id="mergestreams" />
       <label for="mergestreams" class="mediadevice action" data-title="Merge streams"></label>
       <div id="videoView">
+        <div class="viewControls">
+          View: <select name="createView">
+            <option value="simple">Simple</option>
+            <option value="advanced">Advanced</option>
+          </select>
+        </div>
         <input type="radio" name="desktop" class="hiddenCheck streamToggle" id="desktopstream" />
         <label for="desktopstream" class="mediadevice action desktopDevice" data-title="Share desktop" data-target="desktop">
           <video id="desktop" autoplay></video>
@@ -44,12 +54,18 @@
           <span class="placeholder"></span>
           <span class="shadow"></span>
         </label>
-        <ul id="streams">
-          <div class="list">
-          </div>
-          <label type="button" id="addDevice" for="toggleAddDeviceModal"></label>
-        </ul>
       </div>
+      <div id="recordingControls">
+        <button id="pauseRecord" title="Pause recording"></button>
+        <button id="startRecord" title="Start/resume recording"></button>
+        <button id="stopRecord" title="Stop recording"></button>
+        <span id="recordingTime"></span>
+      </div>
+      <ul id="streams">
+        <div class="list">
+        </div>
+        <label type="button" id="addDevice" for="toggleAddDeviceModal"></label>
+      </ul>
     </section>
     <input type="radio" id="edit" class="hiddenCheck" name="view" />
     <section>
@@ -130,6 +146,23 @@
       </p>
     </div>
   </div>
+  <div id="saveCreation" class="modal">
+    <h4>Production details</h4>
+    <div class="modalBody">
+      <ul>
+        <span class="quarterWidth">Title</span><span class="threeQuarterWidth"><input name="title" /></span>
+        <span class="quarterWidth">Presenter</span><span class="threeQuarterWidth"><input name="presenter" /></span>
+        <span class="quarterWidth">Location</span><span class="threeQuarterWidth"><input name="location" /></span>
+      </ul>
+      <h4>Media</h4>
+      <div id="recordingList"></div>
+    </div>
+    <div class="modalFooter">
+      <button class="btn btn-action" id="editRecordings">Edit media</button>
+      <button class="btn btn-success" id="saveRecordings">Save media</button>
+      <label for="toggleSaveCreationModal" class="btn btn-cancel">Discard</label>
+    </div>
+  </div>
   <script src="js/utils.js"></script>
   <script src="js/eventemitter.js"></script>
   <script src="js/devicemanager.js"></script>
@@ -141,5 +174,6 @@
   <script src="js/peerconnection.js"></script>
   <script src="js/qrcode.min.js"></script>
   <script src="js/app.js"></script>
+  <link href="https://fonts.googleapis.com/css?family=Comfortaa:300|Lobster+Two:400" rel="stylesheet">
 </body>
 </html>

--- a/js/speechrecognition.js
+++ b/js/speechrecognition.js
@@ -1,0 +1,154 @@
+var SpeechToText = function(audioAnalyser) {
+  var Recog = (window.webkitSpeechRecognition || window.SpeechRecognition);
+  this.isCapable = !!Recog;
+  this.audioAnalyser = audioAnalyser;
+  this.transcript = [];
+
+  if (this.isCapable) {
+    this.recog = new Recog();
+    this.recog.continuous = true;
+    this.recog.interimResults = true;
+    this.recog.lang = 'en-ZA';
+    this.isRecognising = false;
+    this.recogTimestamp = null;
+    this.grammarList = [];
+    this.audio = new AudioContext();
+
+    this.recog.onstart = e => {
+      this.isRecognising = true;
+    };
+    this.recog.onend = () => {
+      this.isRecognising = false;
+    };
+    this.recog.onresult = e => {
+      let transcription = {
+        timestamp: e.timeStamp,
+        srResult: e.results
+      };
+      if (e.results['0'].isFinal) {
+        this.transcript.push(transcription);
+      }
+      this.notifyDependencies('speechresult', transcription);
+    };
+  }
+
+  var _audioTrack = null;
+  Object.defineProperty(this, 'audioTrack', {
+    get: function() {
+      return _audioTrack;
+    },
+    set: function(track) {
+      if (!_audioTrack && (track instanceof MediaStreamTrack || track instanceof MediaStream)) {
+        _audioTrack = track;
+        this.setTrack(track);
+      }
+    }
+  });
+
+  var micTimeout = null;
+  var silenceLevel = 2;
+  var isMicActive = false;
+
+  Object.defineProperty(this, 'micActive', {
+    get: function() {
+      return isMicActive;
+    },
+    set: function(bool) {
+      if (typeof bool == 'boolean') {
+        isMicActive = bool;
+        var fn = isMicActive ? 'start' : 'stop';
+        if (isMicActive !== this.isRecognising) {
+          this.recog[fn]();
+        }
+      }
+    }
+  });
+
+  this.audioAnalyser.on('magnitude', magnitude => {
+    if (magnitude >= silenceLevel) {
+      clearTimeout(micTimeout);
+      micTimeout = null;
+      if (!isMicActive) {
+        this.micActive = true;
+      }
+    }
+    else if (magnitude < 2 && this.micActive && !micTimeout) {
+      micTimeout = setTimeout(function() {
+        this.micActive = false;
+        clearTimeout(micTimeout);
+        micTimeout = null;
+      }.bind(this), 1000);
+    }
+  });
+
+  var _subscriptions = {};
+  Object.defineProperty(this, 'subscriptions', {
+    get: function() {
+      return _subscriptions;
+    },
+  });
+
+  this.notifyDependencies('capability', this.isCapable);
+}
+
+SpeechToText.prototype = {
+  constructor: SpeechToText,
+  setLanguage: function(lang) {
+    this.recog.lang = lang;
+  },
+  addGrammar: function(grammar) {
+    this.grammarList.push(grammar);
+    var speechRecogList = new (webkitSpeechGrammarList || SpeechGrammarList)();
+    this.grammarList.forEach(function(grammar) {
+      speechRecogList.addFromString(grammar, 1);
+    });
+    this.recog.grammars = speechRecogList;
+  },
+  setTrack: function(track) {
+    setTimeout(() => {
+      var source = this.audio.createMediaStreamSource(track);
+      var delay = this.audio.createDelay(2.0);
+      source.connect(delay);
+      source.connect(this.audio.destination);
+      delay.connect(this.audio.destination);
+      thing = source;
+      this.recog.audioTrack = source.mediaStream.getAudioTracks()[0];
+    }, 2000);
+  },
+  on: function(ev, fn) {
+    if (ev === 'capability') {
+      return fn(this.isCapable);
+    }
+
+    if (!this.subscriptions.hasOwnProperty(ev)) {
+      this.subscriptions[ev] = {};
+    }
+
+    var currentSubscriptions = Object.keys(this.subscriptions);
+
+    let randString = null;
+    do {
+      randString = (1 + Math.random()).toString(36).substring(2, 10);
+    } while (currentSubscriptions.indexOf(randString) > -1);
+
+    this.subscriptions[ev][randString] = fn;
+
+    return randString;
+  },
+  off: function(ev, token) {
+    var result = false;
+    if (this.subscriptions.hasOwnProperty(ev) &&
+         this.subscriptions[ev].hasOwnProperty(token)) {
+      delete this.subscriptions[ev][token];
+      result = true;
+    }
+    return result;
+  },
+  notifyDependencies: function(ev, val) {
+    if (this.subscriptions.hasOwnProperty(ev)) {
+      for (var key in this.subscriptions[ev]) {
+        this.subscriptions[ev][key](val);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Video creation view now has a simplified and advanced view. In addition, code for `MediaStream` recording:

1. Simplified: as the name says, simple. Source streams from the desktop and/or webcam, and record those streams.

2. Initial recording code added. Recorder class is initialised within the Device class, where the following recording events are emitted:
  a. `record.error`, `record.start`. Stubs right now.
  b. `record.prepare`. Emitted when the stop() function is called. The controller uses the information emitted to list devices with recordings.
  c. `record.complete`. Emitted after the recorded data is transformed into a blob (triggered by `MediaRecorder` `onstop` event). Contains a reference to the blob, as well as a url via `createObjectURL`.

3. Recording time is logged below the main webcam stream. Simple hiperftimestamp calculation which takes pausing into consideration.